### PR TITLE
Fix typo in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,5 @@
 Episode:
 
-Sources corrobarting the fix (if relevant):
+Sources corroborating the fix (if relevant):
 
 Twitter:


### PR DESCRIPTION
Fixing a typo in the PR template "corrobarting" -> "corroborating"